### PR TITLE
Fix bug in temporal settings not showing changes

### DIFF
--- a/src/components/manage/Blocks/DataFigure/ImageSidebar.jsx
+++ b/src/components/manage/Blocks/DataFigure/ImageSidebar.jsx
@@ -340,6 +340,7 @@ const ImageSidebar = ({
                 <TemporalWidget
                   value={data}
                   block={block}
+                  id="temporal"
                   onChange={(name, value) => {
                     onChangeBlock(block, {
                       ...data,


### PR DESCRIPTION
After changing values in temporal settings the new changes weren't updated in metadata. The id fix keeps the data updated when new values are saved.