### PR TITLE
Release - temporal widget changes (#65)

### DIFF
--- a/src/components/manage/Blocks/DataFigure/Edit.jsx
+++ b/src/components/manage/Blocks/DataFigure/Edit.jsx
@@ -135,7 +135,7 @@ class Edit extends Component {
       tabledata: null,
       metadata: {},
       geolocation: null,
-      temporal: null,
+      temporal: [],
     },
   };
 

--- a/src/components/manage/Blocks/DataFigure/Metadata.jsx
+++ b/src/components/manage/Blocks/DataFigure/Metadata.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Header, Segment, Menu, Sidebar, Grid } from 'semantic-ui-react';
 import { serializeNodes } from 'volto-slate/editor/render';
+import { TemporalWidgetView } from '@eeacms/volto-widget-temporal-coverage/components';
 import './less/public.less';
 
 /**
@@ -14,9 +15,12 @@ import './less/public.less';
  * @extends Component
  */
 const Metadata = ({ visible, data, hideSidebar }) => {
-  const { geolocation, metadata = {} } = data;
+  const { metadata = {} } = data;
   const { dataSources = {} } = metadata;
   const { value, plaintext = '' } = dataSources;
+
+  let geolocation = data.geolocation || [];
+  let temporal = data.temporal || [];
 
   return (
     <Sidebar
@@ -31,7 +35,7 @@ const Metadata = ({ visible, data, hideSidebar }) => {
     >
       <Segment.Group raised>
         <Segment>
-          <Header style={{ color: '#517776' }} as="h2">
+          <Header as="h2" className={'data-figure-block-header'}>
             Metadata
           </Header>
         </Segment>
@@ -45,16 +49,16 @@ const Metadata = ({ visible, data, hideSidebar }) => {
           </Segment>
         ) : (
           <Segment secondary>
-            <Header style={{ color: '#517776' }} as="h3">
+            <Header as="h3" className={'data-figure-block-header'}>
               Data Sources:
             </Header>
             {serializeNodes(value || [])}
           </Segment>
         )}
-        {geolocation && (
+        {geolocation.length ? (
           <Segment secondary>
-            <Header as="h3" style={{ color: '#517776' }}>
-              Geographic coverage
+            <Header as="h3" className={'data-figure-block-header'}>
+              Geographic coverage:
             </Header>
             <ul>
               <Grid columns={2}>
@@ -74,21 +78,15 @@ const Metadata = ({ visible, data, hideSidebar }) => {
               </Grid>
             </ul>
           </Segment>
-        )}
-        {data.temporal && (
+        ) : null}
+        {temporal.length ? (
           <Segment secondary>
-            <Header as="h3" style={{ color: '#517776' }}>
-              Temporal coverage
+            <Header as="h3" className={'data-figure-block-header'}>
+              Temporal coverage:
             </Header>
-            <div className="data-figure-temporal-coverage">
-              {data.temporal.map((item, index) => (
-                <div key={index} style={{ textIndent: '15px' }}>
-                  {item?.label}
-                </div>
-              ))}
-            </div>
+            <TemporalWidgetView value={temporal} />
           </Segment>
-        )}
+        ) : null}
       </Segment.Group>
     </Sidebar>
   );

--- a/src/components/manage/Blocks/DataFigure/less/public.less
+++ b/src/components/manage/Blocks/DataFigure/less/public.less
@@ -125,9 +125,8 @@
   padding-top: 25px;
 }
 
-.data-figure-temporal-coverage {
-  display: flex;
-  flex-flow: wrap;
+.ui.header.data-figure-block-header {
+  color: #517776;
 }
 
 .data-source-toolbar {

--- a/src/helpers/Svg/Svg.js
+++ b/src/helpers/Svg/Svg.js
@@ -42,7 +42,7 @@ export const isChartSVGImage = (url) =>
 export const isChartImage = (url) => isChartSVGImage(url) || isTableImage(url);
 
 export const extractTemporal = (data = {}) => {
-  return data.temporalCoverage;
+  return data.temporalCoverage || [];
 };
 
 export const extractMetadata = (data = {}) => {


### PR DESCRIPTION
* Refs #136766 metadata template changes:

- normalize header content to contain : at the end of the title
- proper condition for displaying geolocation and temporal data only if we have
  values

* Refs #136766 changed the following:

- use className instead of adding inline styles to headers
- use TemporalWidgetView widget from volto-widget-temporal-coverage to display temporal values

* Refs #136766 provide an empty list as default temporal value:

- this way when uploading an image we don't crash te temporal widget since no vales are set from the image

* Refs #136766 provide fallback empty lists values when checking for geolocation and temporal:

- this way we can condition the addition of the view markup to only show the headers and values
  when we have values to show